### PR TITLE
Verbesserungsvorschläge

### DIFF
--- a/IT2 - Praxisprojekt von Natascha Geisler und Magdalena Kaluza (1).md
+++ b/IT2 - Praxisprojekt von Natascha Geisler und Magdalena Kaluza (1).md
@@ -4,7 +4,7 @@
 
 
 ### Einleitung
-Kontrollierte Vokabulare sind ein bedeutsamer Bestandteil der Arbeit von Bibliotheken, da sie eine strukturierte Wissensorganisation ermöglichen. Für die technische Umsetzung bieten sich die Tools RDF sowie SKOS an, um die Struktur und den Inhalt zu definieren. Als Basis für das vorliegende Projekt und die Publikation eines kontrollierten Vokabulars mit SkoHub Vocabs wurde die Systematik der des Standorts Köln der Katholischen Hochschulbibliothek gewählt. Aufgrund der Vorteile des Datenstandards erscheint die Anwendung für die Darstellung der Systematik einer wissenschaftlichen Bibliothek als sinnvoll. Zweck ist es, dass das kontrollierte Vokabular die Suche in den spezifischen Wissensgebieten strukturiert und vereinfacht. Hierzu trägt unter anderem die Maschinenlesbarkeit bei. 
+Kontrollierte Vokabulare sind ein bedeutsamer Bestandteil der Arbeit von Bibliotheken, da sie eine strukturierte Wissensorganisation ermöglichen. Für die technische Umsetzung bieten sich die Tools RDF sowie SKOS an, um die Struktur und den Inhalt zu definieren. Als Basis für das vorliegende Projekt und die Publikation eines kontrollierten Vokabulars mit SkoHub Vocabs wurde die Systematik des Standorts Köln der Katholischen Hochschulbibliothek gewählt. Aufgrund der Vorteile des Datenstandards erscheint die Anwendung für die Darstellung der Systematik einer wissenschaftlichen Bibliothek als sinnvoll. Zweck ist es, dass das kontrollierte Vokabular die Suche in den spezifischen Wissensgebieten strukturiert und vereinfacht. Hierzu trägt unter anderem die Maschinenlesbarkeit bei.
 
 ### Hierarchie und Beziehungen
 Die Systematik dieser Hochschulbibliothek eignet sich aufgrund ihrer hierarchischen Struktur sehr gut für die Erstellung eines Vokabulars. Die Systematik unterteilt die Themengebiete der Sach- und Fachmedien in fünfzig Kategorien und ordnet diesen jeweils Unterkategorien zu. Die Anzahl der Unterkategorien liegt zwischen einer und vierundsechzig Ordnungsbegriffen, was zur Folge hat, dass die Themenbereiche unterschiedlich detailliert systematisiert werden. Die Themengebiete sind den Unterkategorien hierarchisch übergeordnet, während sich die Unterkategorien auf der gleichen hierarchischen Ebene befinden. 
@@ -23,18 +23,20 @@ Die Festlegung einer Basis-Url, sowie die Definition der Identifier und des Voka
 2.	Die Notation im Kontext der Klassifikation, sowie die vollständige bevorzugte Bezeichnung des Begriffs der Unterkategorie in englischer Sprache.
 3.	Als allgemeine Notiz wird ergänzt, dass die Inhalte des Vokabulars um ausgedachte Ergebnisse ergänzt wurden, um die verwendeten Quellen klar zu definieren. 
 4.	Die Kurzdefinition des Begriffs enthält die Information, dass unter diesem Begriff Medien zum jeweiligen Thema zu finden sind. Dies ist in der konkreten Umsetzung jedoch nicht der Fall, sondern zeigt die Option auf.
-5.	Der direkte Oberbegriff, sowie der skos:broaderTransitive.
+5.	Der direkte Oberbegriff, sowie der `skos:broader`.
 
 Als Code ergibt sich so beispielsweise folgende Begriffsdefinition: 
 
-*<Dro/Allgemeine-Literatur> a skos:Concept ;
+```ttl
+<Dro/Allgemeine-Literatur> a skos:Concept ;
   skos:prefLabel "Dro/Allgemeine Literatur"@de, "Dro/General literature"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Allgemeine Literatur zum Thema Sucht"@de, "General literature on the subject of addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "his vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .*
-  
+```
+
 Die Definierung der Unterbegriffe funktionierte, als hilfreich konstatierte sich hier die Möglichkeit der Überprüfung und Validierung des Teil-Vokabulars mittels „SKOS testing tool“, was bei entstanden Fehlern (beispielsweise versehentlich gesetzte Leerzeichen) den Bereich des Codes mit der Abweichung eingrenzte. Der Turtle Web Editor trug durch die Verwendung von unterschiedlichen Farben zu der Übersichtlichkeit des Codes und der schnellen Fehlerermittlung bei. Auch zeigte sich hier vor allem die Möglichkeit der Hilfestellung und Absprache in der Kleingruppe als sinnvoll. Nach der erfolgreichen Validierung des Vokabulars musste noch eine Entscheidung über die Visualisierung des Codes getroffen werden. Mithilfe des Tools SKOS Play! konnten verschiedene Visualisierungsoptionen getestet werden. Als am besten geeignet erschien aufgrund der Mehrsprachigkeit des Projekt-Vokabulars die Option „Complete edition – multilingual“.
   
 ### Lernziele

--- a/Vokabular.ttl
+++ b/Vokabular.ttl
@@ -1,7 +1,7 @@
 @base <http://www.katho-nrw.de/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02> .
+@prefix skos: <http://www.w3.org/2004/02/skos> .
+@prefix dct: <http://purl.org/dc/terms> .
 
 <> a skos:ConceptScheme ;
   skos:prefLabel "Fachsystematikausschnitt Dr für Sucht"@de, "Specialist system extract Dr for addiction"@en ;
@@ -9,171 +9,171 @@
   dct:description "Fachsystematikausschnitt Dr für Sucht der Katholische Hochschule Nordrhein-Westfalen, Standort Köln"@de, "Specialist system extract Dr for addiction the Catholic University of Applied Sciences North Rhine-Westphalia, Cologne site"@en ;
   dct:issued "2022-01-01" ;
   dct:creator "Katholische Hochschule Nordrhein-Westfalen"@de, "Catholic University of Applied Sciences North Rhine-Westphalia"@en ;
-  skos:hasTopConcept <Dr/Sucht> .
+  skos:hasTopConcept <Dr> .
   
-<Dr/Sucht> a skos:Concept ;
+<Dr> a skos:Concept ;
   skos:prefLabel "Sucht"@de, "Addiction"@en ;
-  skos:narrower <Dro/Allgemeine-Literatur>, <Dra/Suchtkrankenhilfe,-Suchtmedizin,-Sozialarbeit-im-Suchtbereich>, <Drb/Suchtprävention>, <Drc/Alkoholismus>, <Drd/Alkoholismustherapie>, <Dre/Jugendalkoholismus>, <Drf/Eltern-Sucht-Kind,-Kinder-und-Drogen>, <Drg/Frauen-und-Sucht>, <Drk/Drogen-(einzelne-Arten)>, <Drl/Drogenabhängigkeit>, <Drm/Drogenberatung,-Drogenarbeit>, <Drn/Jugend-und-Drogenmissbrauch>,  <Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie>, <Drr/Drogenpolitik>, <Drs/Medikamentenabhängigkeit>, <Drt/Rauchen>, <Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)>, <Drv/Partydrogen:-Ecstasy-etc.>, <Drw/Betriebliche-Suchtberatung>, <Drx/Sucht-im-Alter> ;
+  skos:narrower <Dro/Allgemeine-Literatur>, <Dra/Suchtkrankenhilfe,-Suchtmedizin,-Sozialarbeit-im-Suchtbereich>, <Drb/Suchtprävention>, <Drc/Alkoholismus>, <Drd/Alkoholismustherapie>, <Dre/Jugendalkoholismus>, <Drf/Eltern-Sucht-Kind,-Kinder-und-Drogen>, <Drg/Frauen-und-Sucht>, <Drk/Drogen-(einzelne-Arten)>, <Drl/Drogenabhängigkeit>, <Drm/Drogenberatung,-Drogenarbeit>, <Drn/Jugend-und-Drogenmissbrauch>,  <Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie>, <Drr/Drogenpolitik>, <Drs/Medikamentenabhängigkeit>, <Drt/Rauchen>, <Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)>, <Drv/Partydrogen:-Ecstasy-etc.>, <Drw/Betriebliche-Suchtberatung>, <Drx> ;
   skos:definition "Systematik zum Thema Sucht"@de, "Systematic approach to addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:topConceptOf <> .
 
-<Dro/Allgemeine-Literatur> a skos:Concept ;
+<Dro> a skos:Concept ;
   skos:prefLabel "Allgemeine Literatur"@de, "General literature"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Allgemeine Literatur zum Thema Sucht"@de, "General literature on the subject of addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
 
-<Dra/Suchtkrankenhilfe,-Suchtmedizin,-Sozialarbeit-im-Suchtbereich> a skos:Concept ;
+<Dra> a skos:Concept ;
   skos:prefLabel "Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Media on the topic Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
-<Drb/Suchtprävention> a skos:Concept ;
+<Drb> a skos:Concept ;
   skos:prefLabel "Suchtprävention"@de, "Addiction prevention"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Suchtprävention"@de, "Media on the topic Addiction prevention"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drc/Alkoholismus> a skos:Concept ;
+ <Drc> a skos:Concept ;
   skos:prefLabel "Alkoholismus"@de, "Alcoholism"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Alkoholismus"@de, "Media on the topic Alcoholism"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drd/Alkoholismustherapie> a skos:Concept ;
+ <Drd> a skos:Concept ;
   skos:prefLabel "Alkoholismustherapie"@de, "Alcoholism therapy"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Alkoholismustherapie"@de, "Media on the topic Alcoholism therapy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
     
- <Dre/Jugendalkoholismus> a skos:Concept ;
+ <Dre> a skos:Concept ;
   skos:prefLabel "Jugendalkoholismus"@de, "Youth alcoholism"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Jugendalkoholismus"@de, "Media on the topic Youth alcoholism"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
    
- <Drf/Eltern-Sucht-Kind,-Kinder-und-Drogen> a skos:Concept ;
+ <Drf> a skos:Concept ;
   skos:prefLabel "Eltern-Sucht-Kind, Kinder und Drogen"@de, "Parent-addiction-child, children and drugs"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Eltern-Sucht-Kind, Kinder und Drogen"@de, "Media on the topic Parent-addiction-child, children and drugs"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drg/Frauen-und-Sucht> a skos:Concept ;
+ <Drg> a skos:Concept ;
   skos:prefLabel "Frauen und Sucht"@de, "Women and addiction"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Frauen und Sucht"@de, "Media on the topic Women and addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drk/Drogen-(einzelne-Arten)> a skos:Concept ;
+ <Drk> a skos:Concept ;
   skos:prefLabel "Drogen (einzelne Arten)"@de, "Drugs (individual species)"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zu den einzelnen Drogenarten"@de, "Media on the individual types of drugs"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
    
- <Drl/Drogenabhängigkeit> a skos:Concept ;
+ <Drl> a skos:Concept ;
   skos:prefLabel "Drogenabhängigkeit"@de, "Drug addiction"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Drug addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drm/Drogenberatung,-Drogenarbeit> a skos:Concept ;
+ <Drm> a skos:Concept ;
   skos:prefLabel "Drogenberatung,-Drogenarbeit"@de, "Drug-counseling, Drug-work"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenberatung und Drogenarbeit"@de, "Media on the topic Drug Counseling and Drug Work"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drn/Jugend-und-Drogenmissbrauch> a skos:Concept ;
+ <Drn> a skos:Concept ;
   skos:prefLabel "Jugend-und-Drogenmissbrauch"@de, "Youth-and-drug-abuse"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Jugend und Drogenmissbrauch"@de, "Media on the topic Youth and Drug Abuse"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie> a skos:Concept ;
+ <Drp> a skos:Concept ;
   skos:prefLabel "Drogentherapie,-Suchttherapie,-Substitutionstherapie"@de, "Drug-therapy,-addiction-therapy,-substitution-therapy"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogentherapie, Suchttherapie, Substitutionstherapie"@de, "Media on the topic Drug therapy, addiction therapy, substitution therapy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drr/Drogenpolitik> a skos:Concept ;
+ <Drr> a skos:Concept ;
   skos:prefLabel "Drogenpolitik"@de, "Drug-policy"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenpolitik"@de, "Media on the topic Drug policy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drs/Medikamentenabhängigkeit> a skos:Concept ;
+ <Drs> a skos:Concept ;
   skos:prefLabel "Medikamentenabhängigkeit"@de, "Medication-dependency"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Medikamentenabhängigkeit"@de, "Media on the topic Medication dependency"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drt/Rauchen> a skos:Concept ;
+ <Drt> a skos:Concept ;
   skos:prefLabel "Rauchen"@de, "smoking"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Rauchen"@de, "Media on the topic Smoking"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)> a skos:Concept ;
+ <Dru> a skos:Concept ;
   skos:prefLabel "Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)"@de, "Non-substance-related-addiction (gambling, online addiction, etc.)"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Stoffungebundene Sucht (Glücksspiel, Online-Sucht etc.)"@de, "Media on the topic Non-substance-related addiction (gambling, online addiction, etc.)"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drv/Partydrogen:-Ecstasy-etc.> a skos:Concept ;
+ <Drv> a skos:Concept ;
   skos:prefLabel "Partydrogen:-Ecstasy-etc."@de, "Party-drugs:-ecstasy-etc."@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Party drugs: ecstasy etc"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drw/Betriebliche-Suchtberatung> a skos:Concept ;
+ <Drw> a skos:Concept ;
   skos:prefLabel "Betriebliche-Suchtberatung"@de, "Company-addiction-counseling"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Betriebliche Suchtberatung"@de, "Media on the topic Company addiction counseling"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;
   skos:inScheme <> .
   
- <Drx/Sucht-im-Alter> a skos:Concept ;
+ <Drx> a skos:Concept ;
   skos:prefLabel "Sucht-im-Alter"@de, "Addiction-in-old-age"@en ;
-  skos:broader <Dr/Sucht> ;
+  skos:broader <Dr> ;
   skos:definition "Medien zum Thema Sucht im Alter"@de, "Media on the topic Addiction in old age"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
   skos:note: "Dieses Vokabular ist im Rahmen eines Projektes in einem Masterstudiengeang entstanden"@de, "This vocabulary was created as part of a project in a master's degree program"@en ;

--- a/Vokabular.ttl
+++ b/Vokabular.ttl
@@ -20,7 +20,7 @@
   skos:topConceptOf <> .
 
 <Dro/Allgemeine-Literatur> a skos:Concept ;
-  skos:prefLabel "Dro/Allgemeine Literatur"@de, "Dro/General literature"@en ;
+  skos:prefLabel "Allgemeine Literatur"@de, "General literature"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Allgemeine Literatur zum Thema Sucht"@de, "General literature on the subject of addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -28,7 +28,7 @@
   skos:inScheme <> .
 
 <Dra/Suchtkrankenhilfe,-Suchtmedizin,-Sozialarbeit-im-Suchtbereich> a skos:Concept ;
-  skos:prefLabel "Dra/Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Dra/Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
+  skos:prefLabel "Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Media on the topic Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -36,7 +36,7 @@
   skos:inScheme <> .
   
 <Drb/Suchtprävention> a skos:Concept ;
-  skos:prefLabel "Drb/Suchtprävention"@de, "Drb/Addiction prevention"@en ;
+  skos:prefLabel "Suchtprävention"@de, "Addiction prevention"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Suchtprävention"@de, "Media on the topic Addiction prevention"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -44,7 +44,7 @@
   skos:inScheme <> .
   
  <Drc/Alkoholismus> a skos:Concept ;
-  skos:prefLabel "Drc/Alkoholismus"@de, "Drc/Alcoholism"@en ;
+  skos:prefLabel "Alkoholismus"@de, "Alcoholism"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Alkoholismus"@de, "Media on the topic Alcoholism"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -52,7 +52,7 @@
   skos:inScheme <> .
   
  <Drd/Alkoholismustherapie> a skos:Concept ;
-  skos:prefLabel "Drd/Alkoholismustherapie"@de, "Drd/Alcoholism therapy"@en ;
+  skos:prefLabel "Alkoholismustherapie"@de, "Alcoholism therapy"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Alkoholismustherapie"@de, "Media on the topic Alcoholism therapy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -60,7 +60,7 @@
   skos:inScheme <> .
     
  <Dre/Jugendalkoholismus> a skos:Concept ;
-  skos:prefLabel "Dre/Jugendalkoholismus"@de, "Dre/Youth alcoholism"@en ;
+  skos:prefLabel "Jugendalkoholismus"@de, "Youth alcoholism"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Jugendalkoholismus"@de, "Media on the topic Youth alcoholism"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -68,7 +68,7 @@
   skos:inScheme <> .
    
  <Drf/Eltern-Sucht-Kind,-Kinder-und-Drogen> a skos:Concept ;
-  skos:prefLabel "Drf/Eltern-Sucht-Kind, Kinder und Drogen"@de, "Drf/Parent-addiction-child, children and drugs"@en ;
+  skos:prefLabel "Eltern-Sucht-Kind, Kinder und Drogen"@de, "Parent-addiction-child, children and drugs"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Eltern-Sucht-Kind, Kinder und Drogen"@de, "Media on the topic Parent-addiction-child, children and drugs"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -76,7 +76,7 @@
   skos:inScheme <> .
   
  <Drg/Frauen-und-Sucht> a skos:Concept ;
-  skos:prefLabel "Drg/Frauen und Sucht"@de, "Drg/Women and addiction"@en ;
+  skos:prefLabel "Frauen und Sucht"@de, "Women and addiction"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Frauen und Sucht"@de, "Media on the topic Women and addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -84,7 +84,7 @@
   skos:inScheme <> .
   
  <Drk/Drogen-(einzelne-Arten)> a skos:Concept ;
-  skos:prefLabel "Drk/Drogen (einzelne Arten)"@de, "Drk/Drugs (individual species)"@en ;
+  skos:prefLabel "Drogen (einzelne Arten)"@de, "Drugs (individual species)"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zu den einzelnen Drogenarten"@de, "Media on the individual types of drugs"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -92,7 +92,7 @@
   skos:inScheme <> .
    
  <Drl/Drogenabhängigkeit> a skos:Concept ;
-  skos:prefLabel "Drl/Drogenabhängigkeit"@de, "Drl/Drug addiction"@en ;
+  skos:prefLabel "Drogenabhängigkeit"@de, "Drug addiction"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Drug addiction"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -100,7 +100,7 @@
   skos:inScheme <> .
   
  <Drm/Drogenberatung,-Drogenarbeit> a skos:Concept ;
-  skos:prefLabel "Drm/Drogenberatung,-Drogenarbeit"@de, "Drm/Drug-counseling, Drug-work"@en ;
+  skos:prefLabel "Drogenberatung,-Drogenarbeit"@de, "Drug-counseling, Drug-work"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Drogenberatung und Drogenarbeit"@de, "Media on the topic Drug Counseling and Drug Work"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -108,7 +108,7 @@
   skos:inScheme <> .
   
  <Drn/Jugend-und-Drogenmissbrauch> a skos:Concept ;
-  skos:prefLabel "Drn/Jugend-und-Drogenmissbrauch"@de, "Drn/Youth-and-drug-abuse"@en ;
+  skos:prefLabel "Jugend-und-Drogenmissbrauch"@de, "Youth-and-drug-abuse"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Jugend und Drogenmissbrauch"@de, "Media on the topic Youth and Drug Abuse"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -116,7 +116,7 @@
   skos:inScheme <> .
   
  <Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie> a skos:Concept ;
-  skos:prefLabel "Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie"@de, "Drp/Drug-therapy,-addiction-therapy,-substitution-therapy"@en ;
+  skos:prefLabel "Drogentherapie,-Suchttherapie,-Substitutionstherapie"@de, "Drug-therapy,-addiction-therapy,-substitution-therapy"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Drogentherapie, Suchttherapie, Substitutionstherapie"@de, "Media on the topic Drug therapy, addiction therapy, substitution therapy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -124,7 +124,7 @@
   skos:inScheme <> .
   
  <Drr/Drogenpolitik> a skos:Concept ;
-  skos:prefLabel "Drp/Drogenpolitik"@de, "Drr/Drug-policy"@en ;
+  skos:prefLabel "Drogenpolitik"@de, "Drug-policy"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Drogenpolitik"@de, "Media on the topic Drug policy"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -132,7 +132,7 @@
   skos:inScheme <> .
   
  <Drs/Medikamentenabhängigkeit> a skos:Concept ;
-  skos:prefLabel "Drs/Medikamentenabhängigkeit"@de, "Drs/Medication-dependency"@en ;
+  skos:prefLabel "Medikamentenabhängigkeit"@de, "Medication-dependency"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Medikamentenabhängigkeit"@de, "Media on the topic Medication dependency"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -140,7 +140,7 @@
   skos:inScheme <> .
   
  <Drt/Rauchen> a skos:Concept ;
-  skos:prefLabel "Drt/Rauchen"@de, "Drt/smoking"@en ;
+  skos:prefLabel "Rauchen"@de, "smoking"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Rauchen"@de, "Media on the topic Smoking"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -148,7 +148,7 @@
   skos:inScheme <> .
   
  <Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)> a skos:Concept ;
-  skos:prefLabel "Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)"@de, "Dru/Non-substance-related-addiction (gambling, online addiction, etc.)"@en ;
+  skos:prefLabel "Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)"@de, "Non-substance-related-addiction (gambling, online addiction, etc.)"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Stoffungebundene Sucht (Glücksspiel, Online-Sucht etc.)"@de, "Media on the topic Non-substance-related addiction (gambling, online addiction, etc.)"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -156,7 +156,7 @@
   skos:inScheme <> .
   
  <Drv/Partydrogen:-Ecstasy-etc.> a skos:Concept ;
-  skos:prefLabel "Drv/Partydrogen:-Ecstasy-etc."@de, "Drv/Party-drugs:-ecstasy-etc."@en ;
+  skos:prefLabel "Partydrogen:-Ecstasy-etc."@de, "Party-drugs:-ecstasy-etc."@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Party drugs: ecstasy etc"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -164,7 +164,7 @@
   skos:inScheme <> .
   
  <Drw/Betriebliche-Suchtberatung> a skos:Concept ;
-  skos:prefLabel "Drw/Betriebliche-Suchtberatung"@de, "Drw/Company-addiction-counseling"@en ;
+  skos:prefLabel "Betriebliche-Suchtberatung"@de, "Company-addiction-counseling"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Betriebliche Suchtberatung"@de, "Media on the topic Company addiction counseling"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;
@@ -172,7 +172,7 @@
   skos:inScheme <> .
   
  <Drx/Sucht-im-Alter> a skos:Concept ;
-  skos:prefLabel "Drx/Sucht-im-Alter"@de, "Drx/Addiction-in-old-age"@en ;
+  skos:prefLabel "Sucht-im-Alter"@de, "Addiction-in-old-age"@en ;
   skos:broader <Dr/Sucht> ;
   skos:definition "Medien zum Thema Sucht im Alter"@de, "Media on the topic Addiction in old age"@en ;
   skos:editorialNote "Dieses Beispiel wurde mit ausgedachten Inhalten ergänzt"@de, "This example was supplemented with fictitious content"@en ;

--- a/Vokabular.ttl
+++ b/Vokabular.ttl
@@ -12,6 +12,7 @@
   skos:hasTopConcept <Dr> .
   
 <Dr> a skos:Concept ;
+  skos:notation "Dr" ;
   skos:prefLabel "Sucht"@de, "Addiction"@en ;
   skos:narrower <Dro/Allgemeine-Literatur>, <Dra/Suchtkrankenhilfe,-Suchtmedizin,-Sozialarbeit-im-Suchtbereich>, <Drb/Suchtprävention>, <Drc/Alkoholismus>, <Drd/Alkoholismustherapie>, <Dre/Jugendalkoholismus>, <Drf/Eltern-Sucht-Kind,-Kinder-und-Drogen>, <Drg/Frauen-und-Sucht>, <Drk/Drogen-(einzelne-Arten)>, <Drl/Drogenabhängigkeit>, <Drm/Drogenberatung,-Drogenarbeit>, <Drn/Jugend-und-Drogenmissbrauch>,  <Drp/Drogentherapie,-Suchttherapie,-Substitutionstherapie>, <Drr/Drogenpolitik>, <Drs/Medikamentenabhängigkeit>, <Drt/Rauchen>, <Dru/Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)>, <Drv/Partydrogen:-Ecstasy-etc.>, <Drw/Betriebliche-Suchtberatung>, <Drx> ;
   skos:definition "Systematik zum Thema Sucht"@de, "Systematic approach to addiction"@en ;
@@ -20,6 +21,7 @@
   skos:topConceptOf <> .
 
 <Dro> a skos:Concept ;
+  skos:notation "Dro" ;
   skos:prefLabel "Allgemeine Literatur"@de, "General literature"@en ;
   skos:broader <Dr> ;
   skos:definition "Allgemeine Literatur zum Thema Sucht"@de, "General literature on the subject of addiction"@en ;
@@ -28,6 +30,7 @@
   skos:inScheme <> .
 
 <Dra> a skos:Concept ;
+  skos:notation "Dra" ;
   skos:prefLabel "Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Suchtkrankenhilfe, Suchtmedizin, Sozialarbeit im Suchtbereich"@de, "Media on the topic Addiction treatment, addiction medicine, social work in the field of addiction"@en ;
@@ -36,6 +39,7 @@
   skos:inScheme <> .
   
 <Drb> a skos:Concept ;
+  skos:notation "Drb" ;
   skos:prefLabel "Suchtprävention"@de, "Addiction prevention"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Suchtprävention"@de, "Media on the topic Addiction prevention"@en ;
@@ -44,6 +48,7 @@
   skos:inScheme <> .
   
  <Drc> a skos:Concept ;
+  skos:notation "Drc" ;
   skos:prefLabel "Alkoholismus"@de, "Alcoholism"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Alkoholismus"@de, "Media on the topic Alcoholism"@en ;
@@ -52,6 +57,7 @@
   skos:inScheme <> .
   
  <Drd> a skos:Concept ;
+  skos:notation "Drd" ;
   skos:prefLabel "Alkoholismustherapie"@de, "Alcoholism therapy"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Alkoholismustherapie"@de, "Media on the topic Alcoholism therapy"@en ;
@@ -60,6 +66,7 @@
   skos:inScheme <> .
     
  <Dre> a skos:Concept ;
+  skos:notation "Dre" ;
   skos:prefLabel "Jugendalkoholismus"@de, "Youth alcoholism"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Jugendalkoholismus"@de, "Media on the topic Youth alcoholism"@en ;
@@ -68,6 +75,7 @@
   skos:inScheme <> .
    
  <Drf> a skos:Concept ;
+  skos:notation "Drf" ;
   skos:prefLabel "Eltern-Sucht-Kind, Kinder und Drogen"@de, "Parent-addiction-child, children and drugs"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Eltern-Sucht-Kind, Kinder und Drogen"@de, "Media on the topic Parent-addiction-child, children and drugs"@en ;
@@ -76,6 +84,7 @@
   skos:inScheme <> .
   
  <Drg> a skos:Concept ;
+  skos:notation "Drg" ;
   skos:prefLabel "Frauen und Sucht"@de, "Women and addiction"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Frauen und Sucht"@de, "Media on the topic Women and addiction"@en ;
@@ -84,6 +93,7 @@
   skos:inScheme <> .
   
  <Drk> a skos:Concept ;
+  skos:notation "Drk" ;
   skos:prefLabel "Drogen (einzelne Arten)"@de, "Drugs (individual species)"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zu den einzelnen Drogenarten"@de, "Media on the individual types of drugs"@en ;
@@ -92,6 +102,7 @@
   skos:inScheme <> .
    
  <Drl> a skos:Concept ;
+  skos:notation "Drl" ;
   skos:prefLabel "Drogenabhängigkeit"@de, "Drug addiction"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Drug addiction"@en ;
@@ -100,6 +111,7 @@
   skos:inScheme <> .
   
  <Drm> a skos:Concept ;
+  skos:notation "Drm" ;
   skos:prefLabel "Drogenberatung,-Drogenarbeit"@de, "Drug-counseling, Drug-work"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenberatung und Drogenarbeit"@de, "Media on the topic Drug Counseling and Drug Work"@en ;
@@ -108,6 +120,7 @@
   skos:inScheme <> .
   
  <Drn> a skos:Concept ;
+  skos:notation "Drn" ;
   skos:prefLabel "Jugend-und-Drogenmissbrauch"@de, "Youth-and-drug-abuse"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Jugend und Drogenmissbrauch"@de, "Media on the topic Youth and Drug Abuse"@en ;
@@ -116,6 +129,7 @@
   skos:inScheme <> .
   
  <Drp> a skos:Concept ;
+  skos:notation "Drp" ;
   skos:prefLabel "Drogentherapie,-Suchttherapie,-Substitutionstherapie"@de, "Drug-therapy,-addiction-therapy,-substitution-therapy"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogentherapie, Suchttherapie, Substitutionstherapie"@de, "Media on the topic Drug therapy, addiction therapy, substitution therapy"@en ;
@@ -124,6 +138,7 @@
   skos:inScheme <> .
   
  <Drr> a skos:Concept ;
+  skos:notation "Drr" ;
   skos:prefLabel "Drogenpolitik"@de, "Drug-policy"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenpolitik"@de, "Media on the topic Drug policy"@en ;
@@ -132,6 +147,7 @@
   skos:inScheme <> .
   
  <Drs> a skos:Concept ;
+  skos:notation "Drs" ;
   skos:prefLabel "Medikamentenabhängigkeit"@de, "Medication-dependency"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Medikamentenabhängigkeit"@de, "Media on the topic Medication dependency"@en ;
@@ -140,6 +156,7 @@
   skos:inScheme <> .
   
  <Drt> a skos:Concept ;
+  skos:notation "Drt" ;
   skos:prefLabel "Rauchen"@de, "smoking"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Rauchen"@de, "Media on the topic Smoking"@en ;
@@ -148,6 +165,7 @@
   skos:inScheme <> .
   
  <Dru> a skos:Concept ;
+  skos:notation "Dru" ;
   skos:prefLabel "Stoffungebundene-Sucht-(Glücksspiel,-Online-Sucht-etc.)"@de, "Non-substance-related-addiction (gambling, online addiction, etc.)"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Stoffungebundene Sucht (Glücksspiel, Online-Sucht etc.)"@de, "Media on the topic Non-substance-related addiction (gambling, online addiction, etc.)"@en ;
@@ -156,6 +174,7 @@
   skos:inScheme <> .
   
  <Drv> a skos:Concept ;
+  skos:notation "Drv" ;
   skos:prefLabel "Partydrogen:-Ecstasy-etc."@de, "Party-drugs:-ecstasy-etc."@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Drogenabhängigkeit"@de, "Media on the topic Party drugs: ecstasy etc"@en ;
@@ -164,6 +183,7 @@
   skos:inScheme <> .
   
  <Drw> a skos:Concept ;
+  skos:notation "Drw" ;
   skos:prefLabel "Betriebliche-Suchtberatung"@de, "Company-addiction-counseling"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Betriebliche Suchtberatung"@de, "Media on the topic Company addiction counseling"@en ;
@@ -172,6 +192,7 @@
   skos:inScheme <> .
   
  <Drx> a skos:Concept ;
+  skos:notation "Drx" ;
   skos:prefLabel "Sucht-im-Alter"@de, "Addiction-in-old-age"@en ;
   skos:broader <Dr> ;
   skos:definition "Medien zum Thema Sucht im Alter"@de, "Media on the topic Addiction in old age"@en ;


### PR DESCRIPTION
Es gibt eine extra RDF-Property `skos:notation` zur Angabe der Notation einer Systematikstelle. Diese wurde bisher nicht benutzt, stattdessen steht die Notation einmal in der URI und zum anderen im prefLabel.

Dieser Pull Request:
- entfernt die Notationsangabe aus dem `prefLabel` 6136123d1e12bdc218731f9efe62ae3643819e99
- nutzt nur die Notationen als Basis für die concept-URIs und passt die `@base` URI an (am Ende der Base-URI sollte ein `/` oder ein `#` stehen) 26e4e5d415ede8da411cd1a98f9688196fbec254
- ergänzt `skos:notation` Statements 6b55054884438e2114a78896025bf2978d64e120

Wenn Sie den Pull Request mergen, wird das Vokabular mit den Änderungen neu gebaut.